### PR TITLE
#15 Fix: Fields should be declared at the top of the class, before an…

### DIFF
--- a/src/main/java/casp/web/backend/data/access/layer/event/TypesRegex.java
+++ b/src/main/java/casp/web/backend/data/access/layer/event/TypesRegex.java
@@ -9,10 +9,6 @@ import casp.web.backend.data.access.layer.event.types.Event;
 import casp.web.backend.data.access.layer.event.types.Exam;
 
 public final class TypesRegex {
-
-    private TypesRegex() {
-    }
-
     public static final String BASE_EVENT_TYPES_REGEX = "^" + Event.EVENT_TYPE
             + "|" + Course.EVENT_TYPE
             + "|" + Exam.EVENT_TYPE + "$";
@@ -21,4 +17,6 @@ public final class TypesRegex {
             + "|" + ExamParticipant.PARTICIPANT_TYPE
             + "|" + Space.PARTICIPANT_TYPE + "$";
 
+    private TypesRegex() {
+    }
 }


### PR DESCRIPTION
…y method declarations, constructors, initializers or inner classes.