### PR TITLE
#32 Add version support to OpenAPI configuration

### DIFF
--- a/src/main/java/casp/web/backend/configuration/OpenApiConfig.java
+++ b/src/main/java/casp/web/backend/configuration/OpenApiConfig.java
@@ -22,7 +22,9 @@ class OpenApiConfig {
     OpenAPI openAPI() {
         var bearerKey = "bearer-key";
         var openAPI = new OpenAPI()
-                .info(new Info().title(springdocProperties.getTitle()))
+                .info(new Info()
+                        .title(springdocProperties.getTitle())
+                        .version(springdocProperties.getVersion()))
                 .addSecurityItem(new SecurityRequirement().addList(bearerKey))
                 .components(new Components()
                         .addSecuritySchemes(bearerKey,

--- a/src/main/java/casp/web/backend/configuration/SpringdocProperties.java
+++ b/src/main/java/casp/web/backend/configuration/SpringdocProperties.java
@@ -15,6 +15,7 @@ import java.util.Set;
 class SpringdocProperties {
     private final Set<Server> servers = new HashSet<>();
     private String title;
+    private String version;
 
     Set<Server> getServers() {
         return servers;
@@ -33,5 +34,13 @@ class SpringdocProperties {
 
     void setTitle(final String title) {
         this.title = title;
+    }
+
+    String getVersion() {
+        return version;
+    }
+
+    void setVersion(final String version) {
+        this.version = version;
     }
 }


### PR DESCRIPTION
Included a `version` field in `SpringdocProperties` and integrated it into the OpenAPI metadata. This ensures the API version is now displayed in the OpenAPI documentation, improving clarity and alignment with project metadata.