### PR TITLE
#34 Refactor member queries to support filtering by name

### DIFF
--- a/src/main/java/casp/web/backend/member/MemberService.java
+++ b/src/main/java/casp/web/backend/member/MemberService.java
@@ -14,7 +14,7 @@ public interface MemberService {
 
     Page<MemberDto> getMembersByFirstNameAndLastName(@Nullable String firstName, @Nullable String lastName, Pageable pageable);
 
-    Page<MemberDto> getMembersByEntityStatus(EntityStatus entityStatus, Pageable pageable);
+    Page<MemberDto> getMembersByEntityStatusAndName(EntityStatus entityStatus, @Nullable String name, Pageable pageable);
 
     MemberDto getMemberById(UUID id);
 

--- a/src/main/java/casp/web/backend/member/MemberServiceImpl.java
+++ b/src/main/java/casp/web/backend/member/MemberServiceImpl.java
@@ -60,8 +60,8 @@ class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Page<MemberDto> getMembersByEntityStatus(EntityStatus entityStatus, Pageable pageable) {
-        var memberPage = memberRepository.findAllByEntityStatus(entityStatus, pageable);
+    public Page<MemberDto> getMembersByEntityStatusAndName(EntityStatus entityStatus, String name, Pageable pageable) {
+        var memberPage = memberRepository.findAllByEntityStatusAndName(entityStatus, name, pageable);
         return MEMBER_MAPPER.toTargetPage(memberPage);
     }
 
@@ -109,7 +109,7 @@ class MemberServiceImpl implements MemberService {
 
     @Override
     public Page<MemberDto> getMembersByName(String name, Pageable pageable) {
-        var memberPage = memberRepository.findAllByValue(name, pageable);
+        var memberPage = memberRepository.findAllByEntityStatusAndName(EntityStatus.ACTIVE, name, pageable);
         return MEMBER_MAPPER.toTargetPage(memberPage);
     }
 

--- a/src/main/java/casp/web/backend/member/data/MemberCustomRepository.java
+++ b/src/main/java/casp/web/backend/member/data/MemberCustomRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 public interface MemberCustomRepository {
     Page<Member> findAllByFirstNameAndLastName(@Nullable String firstName, @Nullable String lastName, Pageable pageable);
 
-    Page<Member> findAllByValue(@Nullable String value, Pageable pageable);
+    Page<Member> findAllByEntityStatusAndName(EntityStatus entityStatus, @Nullable String name, Pageable pageable);
 
     Member findByIdAndEntityStatusCustom(UUID id, EntityStatus entityStatus);
 }

--- a/src/main/java/casp/web/backend/member/data/MemberCustomRepositoryImpl.java
+++ b/src/main/java/casp/web/backend/member/data/MemberCustomRepositoryImpl.java
@@ -56,10 +56,10 @@ class MemberCustomRepositoryImpl implements MemberCustomRepository {
     }
 
     @Override
-    public Page<Member> findAllByValue(String value, Pageable pageable) {
-        var expression = MEMBER.entityStatus.eq(EntityStatus.ACTIVE);
-        if (ObjectUtils.isNotEmpty(value)) {
-            expression = expression.andAnyOf(splitIntoWords(value));
+    public Page<Member> findAllByEntityStatusAndName(EntityStatus entityStatus, String name, Pageable pageable) {
+        var expression = MEMBER.entityStatus.eq(entityStatus);
+        if (ObjectUtils.isNotEmpty(name)) {
+            expression = expression.andAnyOf(splitIntoWords(name));
         }
         return createQuery().where(expression)
                 .fetchPage(pageable);

--- a/src/main/java/casp/web/backend/member/data/MemberRepository.java
+++ b/src/main/java/casp/web/backend/member/data/MemberRepository.java
@@ -3,8 +3,6 @@ package casp.web.backend.member.data;
 import casp.web.backend.common.base.BaseRepository;
 import casp.web.backend.common.enums.EntityStatus;
 import org.javers.spring.annotation.JaversSpringDataAuditable;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.Set;
@@ -12,8 +10,6 @@ import java.util.UUID;
 
 @JaversSpringDataAuditable
 public interface MemberRepository extends BaseRepository<Member>, MemberCustomRepository {
-
-    Page<Member> findAllByEntityStatus(EntityStatus entityStatus, Pageable pageable);
 
     Optional<Member> findOneByEmail(String email);
 

--- a/src/main/java/casp/web/backend/member/presentation/MemberRestController.java
+++ b/src/main/java/casp/web/backend/member/presentation/MemberRestController.java
@@ -41,8 +41,9 @@ class MemberRestController {
 
     @GetMapping
     ResponseEntity<Page<MemberRead>> getMembers(@RequestParam EntityStatusParam entityStatusParam,
+                                                @RequestParam(required = false, defaultValue = "") String name,
                                                 @ParameterObject Pageable pageable) {
-        var memberDtoPage = memberService.getMembersByEntityStatus(entityStatusParam.getEntityStatus(), pageable);
+        var memberDtoPage = memberService.getMembersByEntityStatusAndName(entityStatusParam.getEntityStatus(), name, pageable);
         return ResponseEntity.ok(READ_MAPPER.toTargetPage(memberDtoPage));
     }
 

--- a/src/test/java/casp/web/backend/member/MemberServiceImplTest.java
+++ b/src/test/java/casp/web/backend/member/MemberServiceImplTest.java
@@ -91,11 +91,12 @@ class MemberServiceImplTest {
     }
 
     @Test
-    void getMembersByEntityStatus() {
+    void getMembersByEntityStatusAndName() {
         var page = new PageImpl<>(List.of(member));
-        when(memberRepository.findAllByEntityStatus(EntityStatus.ACTIVE, Pageable.unpaged())).thenReturn(page);
+        var name = "name";
+        when(memberRepository.findAllByEntityStatusAndName(EntityStatus.ACTIVE, name, Pageable.unpaged())).thenReturn(page);
 
-        var memberDtoPage = memberService.getMembersByEntityStatus(EntityStatus.ACTIVE, Pageable.unpaged());
+        var memberDtoPage = memberService.getMembersByEntityStatusAndName(EntityStatus.ACTIVE, name, Pageable.unpaged());
 
         assertThat(memberDtoPage).containsExactly(MEMBER_MAPPER.toTarget(member));
     }
@@ -103,7 +104,7 @@ class MemberServiceImplTest {
     @Test
     void getMembersByName() {
         var page = new PageImpl<>(List.of(member));
-        when(memberRepository.findAllByValue(member.getLastName(), Pageable.unpaged())).thenReturn(page);
+        when(memberRepository.findAllByEntityStatusAndName(EntityStatus.ACTIVE, member.getLastName(), Pageable.unpaged())).thenReturn(page);
 
         var memberDtoPage = memberService.getMembersByName(member.getLastName(), Pageable.unpaged());
 

--- a/src/test/java/casp/web/backend/member/data/MemberCustomRepositoryImplTest.java
+++ b/src/test/java/casp/web/backend/member/data/MemberCustomRepositoryImplTest.java
@@ -77,17 +77,17 @@ class MemberCustomRepositoryImplTest {
         @NullAndEmptySource
         @ValueSource(strings = {"    "})
         void findAllWithoutValue(String name) {
-            assertThat(memberRepository.findAllByValue(name, Pageable.unpaged())).containsExactlyInAnyOrder(doe, john);
+            assertThat(memberRepository.findAllByEntityStatusAndName(EntityStatus.ACTIVE, name, Pageable.unpaged())).containsExactlyInAnyOrder(doe, john);
         }
 
         @Test
         void findOneByName() {
-            assertThat(memberRepository.findAllByValue("John", Pageable.unpaged())).containsExactly(john);
+            assertThat(memberRepository.findAllByEntityStatusAndName(EntityStatus.ACTIVE, "John", Pageable.unpaged())).containsExactly(john);
         }
 
         @Test
         void findAllByMultipleLettersSeparatedBySpaces() {
-            assertThat(memberRepository.findAllByValue("J X D", Pageable.unpaged())).containsExactlyInAnyOrder(doe, john);
+            assertThat(memberRepository.findAllByEntityStatusAndName(EntityStatus.ACTIVE, "J X D", Pageable.unpaged())).containsExactlyInAnyOrder(doe, john);
         }
     }
 

--- a/src/test/java/casp/web/backend/member/presentation/MemberRestControllerTest.java
+++ b/src/test/java/casp/web/backend/member/presentation/MemberRestControllerTest.java
@@ -42,9 +42,10 @@ class MemberRestControllerTest {
 
     @Test
     void getMembers() {
-        when(memberService.getMembersByEntityStatus(EntityStatus.ACTIVE, Pageable.unpaged())).thenReturn(new PageImpl<>(List.of(memberDto)));
+        var name = "name";
+        when(memberService.getMembersByEntityStatusAndName(EntityStatus.ACTIVE, name, Pageable.unpaged())).thenReturn(new PageImpl<>(List.of(memberDto)));
 
-        var response = memberRestController.getMembers(EntityStatusParam.ACTIVE, Pageable.unpaged());
+        var response = memberRestController.getMembers(EntityStatusParam.ACTIVE, name, Pageable.unpaged());
 
         assertSame(HttpStatus.OK, response.getStatusCode());
         assertThat(response.getBody()).containsExactly(READ_MAPPER.toTarget(memberDto));


### PR DESCRIPTION
Updated methods and repository queries to include an optional name filter alongside entity status. Adjusted service, controller, and test layers to accommodate the new query logic for improved filtering functionality.