### PR TITLE
Remove unused imports in test classes

### DIFF
--- a/src/test/java/casp/web/backend/calendar/presentation/CourseRestControllerTest.java
+++ b/src/test/java/casp/web/backend/calendar/presentation/CourseRestControllerTest.java
@@ -9,11 +9,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/casp/web/backend/dog/presentation/DogHasHandlerRestControllerTest.java
+++ b/src/test/java/casp/web/backend/dog/presentation/DogHasHandlerRestControllerTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 import java.util.Set;


### PR DESCRIPTION
Eliminated unused `ResponseEntity` and `Page` imports from test files in the `DogHasHandlerRestControllerTest` and `CourseRestControllerTest` classes. This improves code readability and adheres to clean coding practices.