### PR TITLE
Remove unused `toSpaceDto` method from CourseMapper  

### DIFF
--- a/src/main/java/casp/web/backend/calendar/CourseMapper.java
+++ b/src/main/java/casp/web/backend/calendar/CourseMapper.java
@@ -12,11 +12,4 @@ public interface CourseMapper extends BaseEventMapper<Course, CourseDto> {
     SpaceDto toSpaceDto(Space space);
 
     Space toSpace(SpaceDto spaceDto);
-
-    default SpaceDto toSpaceDto(Space space, Course course) {
-        var spaceDto = toSpaceDto(space);
-        spaceDto.setCourseId(course.getId());
-        spaceDto.setCourseName(course.getName());
-        return spaceDto;
-    }
 }


### PR DESCRIPTION
The `toSpaceDto(Space, Course)` method was identified as redundant and has been removed from the `CourseMapper` class. This cleanup improves code maintainability and adheres to clean code principles.

### Changes Made
- Deleted the unused `toSpaceDto` method from `CourseMapper`.

### Checklist
- [ ] Tests have been added or updated where necessary.
- [ ] Documentation reflects the changes made.
- [ ] Code changes have been reviewed and approved.

No additional functionality or logic modifications are included in this pull request.